### PR TITLE
relay: introduce ConnectContext for better control over network latency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/valyala/fastjson v1.6.3
 	golang.org/x/exp v0.0.0-20221106115401-f9659909a136
+	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20221106115401-f9659909a136 h1:Fq7F/w7MAa1KJ5bt2aJ62ihqp9HDcRuyILskkpIAurw=
 golang.org/x/exp v0.0.0-20221106115401-f9659909a136/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/relay_test.go
+++ b/relay_test.go
@@ -1,0 +1,72 @@
+package nostr
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+func TestConnectContext(t *testing.T) {
+	// fake relay server
+	var mu sync.Mutex // guards connected to satisfy go test -race
+	var connected bool
+	ws := newWebsocketServer(func(conn *websocket.Conn) {
+		mu.Lock()
+		connected = true
+		mu.Unlock()
+		io.ReadAll(conn) // discard all input
+	})
+	defer ws.Close()
+
+	// relay client
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	r, err := RelayConnectContext(ctx, ws.URL)
+	if err != nil {
+		t.Fatalf("RelayConnectContext: %v", err)
+	}
+	defer r.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !connected {
+		t.Error("fake relay server saw no client connect")
+	}
+}
+
+func TestConnectContextCanceled(t *testing.T) {
+	// fake relay server
+	ws := newWebsocketServer(func(conn *websocket.Conn) {
+		io.ReadAll(conn) // discard all input
+	})
+	defer ws.Close()
+
+	// relay client
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // make ctx expired
+	_, err := RelayConnectContext(ctx, ws.URL)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("RelayConnectContext returned %v error; want context.Canceled", err)
+	}
+}
+
+func newWebsocketServer(handler func(*websocket.Conn)) *httptest.Server {
+	return httptest.NewServer(&websocket.Server{
+		Handshake: anyOriginHandshake,
+		Handler:   handler,
+	})
+}
+
+// anyOriginHandshake is an alternative to default in golang.org/x/net/websocket
+// which checks for origin. nostr client sends no origin and it makes no difference
+// for the tests here anyway.
+var anyOriginHandshake = func(conf *websocket.Config, r *http.Request) error {
+	return nil
+}


### PR DESCRIPTION
A websocket dial may hand for an unreasonably long time and a nostr client has no control over this when trying to connect to a relay.

Go started introducing context in networking since 2014 - see https://go.dev/blog/context - and by now many net functions have XxxContext equivalent, such as DialContext.

Example usage of the change introduced by this commit:

    ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
    defer cancel()
    r, err := nostr.RelayConnectContext(ctx, "ws://relay.example.org")

The code above makes RelayConnectContext last at most 3 sec, returning an error if a connection cannot be established in the given time. This helps whenever a tight control over connection latency is required, such as distributed systems.

The change is backwards-compatible except the case where RelayPool.Add sent an error over the returned channel without actually closing said channel. I believe it was a bug.