### PR TITLE
use crypto/rand instead of math/rand in relay.go for REQ <id>

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -2,11 +2,11 @@ package nostr
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
-	"math/rand"
 	"time"
 
 	s "github.com/SaveTheRbtz/generic-sync-map-go"


### PR DESCRIPTION
I was getting some duplicate "REQ" ID's when using noscl publish. 

Tracked it down to math/rand usage instead of crypto/rand in relay.go


