### PR TITLE
Problem: console is spammed with invalid sig error

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -135,16 +135,9 @@ func (r *Relay) ConnectContext(ctx context.Context) error {
 					json.Unmarshal(jsonMessage[2], &event)
 
 					// check signature of all received events, ignore invalid
-					ok, err := event.CheckSignature()
-					if !ok {
-						errmsg := ""
-						if err != nil {
-							errmsg = err.Error()
-						}
-						log.Printf("bad signature: %s", errmsg)
+					if ok, err := event.CheckSignature(); !ok {
 						continue
 					}
-
 					// check if the event matches the desired filter, ignore otherwise
 					if !subscription.Filters.Match(&event) {
 						continue


### PR DESCRIPTION
When (for example) subscribing to all kind 1 events the console gets filled up with:
```
2022/12/25 23:39:51 bad signature:
2022/12/25 23:39:51 bad signature:
2022/12/25 23:39:51 bad signature:
2022/12/25 23:39:51 bad signature:
2022/12/25 23:39:51 bad signature:
2022/12/25 23:39:51 bad signature:
2022/12/25 23:39:51 bad signature:
```

The error is not very helpful, should be safe enough to just drop anything with an invalid sig.