### PR TITLE
trim trailing slash from expected and found relay URL, clean up

### DIFF
--- a/nip42/nip42.go
+++ b/nip42/nip42.go
@@ -26,7 +26,7 @@ func CreateUnsignedAuthEvent(challenge, pubkey, relayURL string) nostr.Event {
 // ValidateAuthEvent checks whether event is a valid NIP-42 event for given challenge and relayURL.
 // The result of the validation is encoded in the ok bool.
 func ValidateAuthEvent(event *nostr.Event, challenge string, relayURL string) (pubkey string, ok bool) {
-	if ok, _ := event.CheckSignature(); ok == false {
+	if ok, _ := event.CheckSignature(); !ok {
 		return "", false
 	}
 	if event.Kind != 22242 {

--- a/nip42/nip42.go
+++ b/nip42/nip42.go
@@ -42,12 +42,20 @@ func ValidateAuthEvent(event *nostr.Event, challenge string, relayURL string) (p
 		return "", false
 	}
 
-	expected, err := url.Parse(strings.TrimSuffix(relayURL, "/"))
+	parseUrl := func(input string) (*url.URL, error) {
+		return url.Parse(
+			strings.ToLower(
+				strings.TrimSuffix(input, "/"),
+			),
+		)
+	}
+
+	expected, err := parseUrl(relayURL)
 	if err != nil {
 		return "", false
 	}
 
-	found, err := url.Parse(strings.TrimSuffix(event.Tags.GetFirst([]string{"relay", ""}).Value(), "/"))
+	found, err := parseUrl(event.Tags.GetFirst([]string{"relay", ""}).Value())
 	if err != nil {
 		return "", false
 	}

--- a/nip42/nip42.go
+++ b/nip42/nip42.go
@@ -2,6 +2,7 @@ package nip42
 
 import (
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/nbd-wtf/go-nostr"
@@ -41,16 +42,20 @@ func ValidateAuthEvent(event *nostr.Event, challenge string, relayURL string) (p
 		return "", false
 	}
 
-	expected, err1 := url.Parse(relayURL)
-	found, err2 := url.Parse(event.Tags.GetFirst([]string{"relay", ""}).Value())
-	if err1 != nil || err2 != nil {
+	expected, err := url.Parse(strings.TrimSuffix(relayURL, "/"))
+	if err != nil {
 		return "", false
-	} else {
-		if expected.Scheme != found.Scheme ||
-			expected.Host != found.Host ||
-			expected.Path != found.Path {
-			return "", false
-		}
+	}
+
+	found, err := url.Parse(strings.TrimSuffix(event.Tags.GetFirst([]string{"relay", ""}).Value(), "/"))
+	if err != nil {
+		return "", false
+	}
+
+	if expected.Scheme != found.Scheme ||
+		expected.Host != found.Host ||
+		expected.Path != found.Path {
+		return "", false
 	}
 
 	return event.PubKey, true


### PR DESCRIPTION
Trim the trailing slash when comparing the expected and found WS URLs to avoid conflicts.

Was considering also doing case insensitive, @fiatjaf what do you think? I can make a quick update to include that too.