### PR TITLE
finishing work on marshaling/serialization bug

### DIFF
--- a/event.go
+++ b/event.go
@@ -46,7 +46,7 @@ func (evt *Event) GetID() string {
 
 // Serialize outputs a byte array that can be hashed/signed to identify/authenticate.
 // JSON encoding as defined in RFC4627.
-func (evt Event) Serialize() []byte {
+func (evt *Event) Serialize() []byte {
 	// the serialization process is just putting everything into a JSON array
 	// so the order is kept. See NIP-01
 	dst := make([]byte, 0)

--- a/event.go
+++ b/event.go
@@ -62,7 +62,7 @@ func (evt *Event) Serialize() []byte {
 		))...)
 
 	// tags
-	dst = evt.Tags.marshalTo(dst)
+	dst = evt.Tags.MarshalTo(dst)
 	dst = append(dst, ',')
 
 	// content needs to be escaped in general as it is user generated.

--- a/event.go
+++ b/event.go
@@ -10,13 +10,13 @@ import (
 )
 
 type Event struct {
-	ID        string    `json:"id"`
-	PubKey    string    `json:"pubkey"`
-	CreatedAt time.Time `json:"created_at"`
-	Kind      int       `json:"kind"`
-	Tags      Tags      `json:"tags"`
-	Content   string    `json:"content"`
-	Sig       string    `json:"sig"`
+	ID        string
+	PubKey    string
+	CreatedAt time.Time
+	Kind      int
+	Tags      Tags
+	Content   string
+	Sig       string
 
 	// anything here will be mashed together with the main event object when serializing
 	extra map[string]any

--- a/event.go
+++ b/event.go
@@ -10,13 +10,13 @@ import (
 )
 
 type Event struct {
-	ID        string
-	PubKey    string
-	CreatedAt time.Time
-	Kind      int
-	Tags      Tags
-	Content   string
-	Sig       string
+	ID        string    `json:"id"`
+	PubKey    string    `json:"pubkey"`
+	CreatedAt time.Time `json:"created_at"`
+	Kind      int       `json:"kind"`
+	Tags      Tags      `json:"tags"`
+	Content   string    `json:"content"`
+	Sig       string    `json:"sig"`
 
 	// anything here will be mashed together with the main event object when serializing
 	extra map[string]any

--- a/event.go
+++ b/event.go
@@ -46,7 +46,7 @@ func (evt *Event) GetID() string {
 
 // Serialize outputs a byte array that can be hashed/signed to identify/authenticate.
 // JSON encoding as defined in RFC4627.
-func (evt *Event) Serialize() []byte {
+func (evt Event) Serialize() []byte {
 	// the serialization process is just putting everything into a JSON array
 	// so the order is kept. See NIP-01
 	dst := make([]byte, 0)

--- a/event.go
+++ b/event.go
@@ -62,7 +62,7 @@ func (evt *Event) Serialize() []byte {
 		))...)
 
 	// tags
-	dst = evt.Tags.MarshalTo(dst)
+	dst = evt.Tags.marshalTo(dst)
 	dst = append(dst, ',')
 
 	// content needs to be escaped in general as it is user generated.

--- a/event_aux.go
+++ b/event_aux.go
@@ -115,7 +115,7 @@ func (evt *Event) MarshalJSON() ([]byte, error) {
 		evt.CreatedAt.Unix(),
 		evt.Kind,
 	))...)
-	dst = evt.Tags.marshalTo(dst)
+	dst = evt.Tags.MarshalTo(dst)
 	dst = append(dst, []byte(",\"content\":")...)
 	dst = escapeString(dst, evt.Content)
 	dst = append(dst, []byte(fmt.Sprintf(",\"sig\":\"%s\"",

--- a/event_aux.go
+++ b/event_aux.go
@@ -1,11 +1,11 @@
 package nostr
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"time"
-
 	"github.com/valyala/fastjson"
+	"time"
 )
 
 func (evt *Event) UnmarshalJSON(payload []byte) error {
@@ -74,35 +74,10 @@ func (evt *Event) UnmarshalJSON(payload []byte) error {
 			evt.extra[key] = anyValue
 		}
 	})
-	if visiterr != nil {
-		return visiterr
-	}
-
-	return nil
+	return visiterr
 }
 
-func (evt Event) MarshalJSON() ([]byte, error) {
-	var arena fastjson.Arena
-
-	o := arena.NewObject()
-	o.Set("id", arena.NewString(evt.ID))
-	o.Set("pubkey", arena.NewString(evt.PubKey))
-	o.Set("created_at", arena.NewNumberInt(int(evt.CreatedAt.Unix())))
-	o.Set("kind", arena.NewNumberInt(evt.Kind))
-	o.Set("tags", tagsToFastjsonArray(&arena, evt.Tags))
-	o.Set("content", arena.NewString(evt.Content))
-	o.Set("sig", arena.NewString(evt.Sig))
-
-	for k, v := range evt.extra {
-		b, _ := json.Marshal(v)
-		if val, err := fastjson.ParseBytes(b); err == nil {
-			o.Set(k, val)
-		}
-	}
-
-	return o.MarshalTo(nil), nil
-}
-
+// unmarshaling helper
 func fastjsonArrayToTags(v *fastjson.Value) (Tags, error) {
 	arr, err := v.Array()
 	if err != nil {
@@ -130,14 +105,37 @@ func fastjsonArrayToTags(v *fastjson.Value) (Tags, error) {
 	return sll, nil
 }
 
-func tagsToFastjsonArray(arena *fastjson.Arena, tags Tags) *fastjson.Value {
-	jtags := arena.NewArray()
-	for i, v := range tags {
-		arr := arena.NewArray()
-		for j, subv := range v {
-			arr.SetArrayItem(j, arena.NewString(subv))
+// MarshalJSON() returns the JSON byte encoding of the event, as in NIP-01.
+func (evt *Event) MarshalJSON() ([]byte, error) {
+	dst := make([]byte, 0)
+	dst = append(dst, '{')
+	dst = append(dst, []byte(fmt.Sprintf("\"id\":\"%s\",\"pubkey\":\"%s\",\"created_at\":%d,\"kind\":%d,\"tags\":",
+		evt.ID,
+		evt.PubKey,
+		evt.CreatedAt.Unix(),
+		evt.Kind,
+	))...)
+	dst = evt.Tags.marshalTo(dst)
+	dst = append(dst, []byte(",\"content\":")...)
+	dst = escapeString(dst, evt.Content)
+	dst = append(dst, []byte(fmt.Sprintf(",\"sig\":\"%s\"",
+		evt.Sig,
+	))...)
+	// slower marshaling of "any" interface type
+	if evt.extra != nil {
+		buf := bytes.NewBuffer(nil)
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		for k, v := range evt.extra {
+			if e := enc.Encode(v); e == nil {
+				dst = append(dst, ',')
+				dst = escapeString(dst, k)
+				dst = append(dst, ':')
+				dst = append(dst, buf.Bytes()[:buf.Len()-1]...)
+			}
+			buf.Reset()
 		}
-		jtags.SetArrayItem(i, arr)
 	}
-	return jtags
+	dst = append(dst, '}')
+	return dst, nil
 }

--- a/event_aux.go
+++ b/event_aux.go
@@ -115,7 +115,7 @@ func (evt Event) MarshalJSON() ([]byte, error) {
 		evt.CreatedAt.Unix(),
 		evt.Kind,
 	))...)
-	dst = evt.Tags.MarshalTo(dst)
+	dst = evt.Tags.marshalTo(dst)
 	dst = append(dst, []byte(",\"content\":")...)
 	dst = escapeString(dst, evt.Content)
 	dst = append(dst, []byte(fmt.Sprintf(",\"sig\":\"%s\"",

--- a/event_aux.go
+++ b/event_aux.go
@@ -106,7 +106,7 @@ func fastjsonArrayToTags(v *fastjson.Value) (Tags, error) {
 }
 
 // MarshalJSON() returns the JSON byte encoding of the event, as in NIP-01.
-func (evt *Event) MarshalJSON() ([]byte, error) {
+func (evt Event) MarshalJSON() ([]byte, error) {
 	dst := make([]byte, 0)
 	dst = append(dst, '{')
 	dst = append(dst, []byte(fmt.Sprintf("\"id\":\"%s\",\"pubkey\":\"%s\",\"created_at\":%d,\"kind\":%d,\"tags\":",

--- a/helpers.go
+++ b/helpers.go
@@ -35,3 +35,43 @@ func ContainsPrefixOf(haystack []string, needle string) bool {
 	}
 	return false
 }
+
+// Escaping strings for JSON encoding according to RFC8259.
+// Also encloses result in quotation marks "".
+func escapeString(dst []byte, s string) []byte {
+	dst = append(dst, '"')
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '"':
+			// quotation mark
+			dst = append(dst, []byte{'\\', '"'}...)
+		case c == '\\':
+			// reverse solidus
+			dst = append(dst, []byte{'\\', '\\'}...)
+		case c >= 0x20:
+			// default, rest below are control chars
+			dst = append(dst, c)
+		case c == 0x08:
+			dst = append(dst, []byte{'\\', 'b'}...)
+		case c < 0x09:
+			dst = append(dst, []byte{'\\', 'u', '0', '0', '0', '0' + c}...)
+		case c == 0x09:
+			dst = append(dst, []byte{'\\', 't'}...)
+		case c == 0x0a:
+			dst = append(dst, []byte{'\\', 'n'}...)
+		case c == 0x0c:
+			dst = append(dst, []byte{'\\', 'f'}...)
+		case c == 0x0d:
+			dst = append(dst, []byte{'\\', 'r'}...)
+		case c < 0x10:
+			dst = append(dst, []byte{'\\', 'u', '0', '0', '0', 0x57 + c}...)
+		case c < 0x1a:
+			dst = append(dst, []byte{'\\', 'u', '0', '0', '1', 0x20 + c}...)
+		case c < 0x20:
+			dst = append(dst, []byte{'\\', 'u', '0', '0', '1', 0x47 + c}...)
+		}
+	}
+	dst = append(dst, '"')
+	return dst
+}

--- a/relay.go
+++ b/relay.go
@@ -229,7 +229,15 @@ func (r *Relay) Publish(ctx context.Context, event Event) Status {
 	defer r.okCallbacks.Delete(event.ID)
 
 	// publish event
-	if err := r.Connection.WriteJSON([]interface{}{"EVENT", event}); err != nil {
+	message := []byte("[\"EVENT\",")
+	if m, e := event.MarshalJSON(); e == nil {
+		message = append(message, m...)
+		message = append(message, ']')
+	} else {
+		return status
+	}
+
+	if err := r.Connection.WriteMessage(websocket.TextMessage, message); err != nil {
 		return status
 	}
 

--- a/relay.go
+++ b/relay.go
@@ -229,15 +229,7 @@ func (r *Relay) Publish(ctx context.Context, event Event) Status {
 	defer r.okCallbacks.Delete(event.ID)
 
 	// publish event
-	message := []byte("[\"EVENT\",")
-	if m, e := event.MarshalJSON(); e == nil {
-		message = append(message, m...)
-		message = append(message, ']')
-	} else {
-		return status
-	}
-
-	if err := r.Connection.WriteMessage(websocket.TextMessage, message); err != nil {
+	if err := r.Connection.WriteJSON([]interface{}{"EVENT", event}); err != nil {
 		return status
 	}
 

--- a/relay.go
+++ b/relay.go
@@ -312,7 +312,6 @@ func (r *Relay) Auth(ctx context.Context, event Event) Status {
 	if err := r.Connection.WriteMessage(websocket.TextMessage, message); err != nil {
 		return status
 	}
-
 	// use mu.Lock() just in case the okCallback got called, extremely unlikely.
 	mu.Lock()
 	status = PublishStatusSent

--- a/relay.go
+++ b/relay.go
@@ -139,16 +139,14 @@ func (r *Relay) Connect(ctx context.Context) error {
 				json.Unmarshal(jsonMessage[1], &channel)
 				if subscription, ok := r.subscriptions.Load(channel); ok {
 					var event Event
-					json.Unmarshal(jsonMessage[2], &event)
+					if err := (&event).UnmarshalJSON(jsonMessage[2]); err != nil {
+						log.Printf("unmarshaling error: %s", err.Error())
+						continue
+					}
 
 					// check signature of all received events, ignore invalid
-					ok, err := event.CheckSignature()
-					if !ok {
-						errmsg := ""
-						if err != nil {
-							errmsg = err.Error()
-						}
-						log.Printf("bad signature: %s", errmsg)
+					if ok, err := event.CheckSignature(); !ok {
+						log.Printf("bad signature: %s", err.Error())
 						continue
 					}
 
@@ -304,10 +302,17 @@ func (r *Relay) Auth(ctx context.Context, event Event) Status {
 	defer r.okCallbacks.Delete(event.ID)
 
 	// send AUTH
-	if err := r.Connection.WriteJSON([]interface{}{"AUTH", event}); err != nil {
-		// status will be "failed"
+	message := []byte("[\"AUTH\",")
+	if m, e := event.MarshalJSON(); e == nil {
+		message = append(message, m...)
+		message = append(message, ']')
+	} else {
 		return status
 	}
+	if err := r.Connection.WriteMessage(websocket.TextMessage, message); err != nil {
+		return status
+	}
+
 	// use mu.Lock() just in case the okCallback got called, extremely unlikely.
 	mu.Lock()
 	status = PublishStatusSent

--- a/tags.go
+++ b/tags.go
@@ -12,11 +12,16 @@ type Tag []string
 
 // StartsWith checks if a tag contains a prefix.
 // for example,
-//     ["p", "abcdef...", "wss://relay.com"]
+//
+//	["p", "abcdef...", "wss://relay.com"]
+//
 // would match against
-//     ["p", "abcdef..."]
+//
+//	["p", "abcdef..."]
+//
 // or even
-//     ["p", "abcdef...", "wss://"]
+//
+//	["p", "abcdef...", "wss://"]
 func (tag Tag) StartsWith(prefix []string) bool {
 	prefixLen := len(prefix)
 
@@ -155,8 +160,9 @@ func (tag Tag) marshalTo(dst []byte) []byte {
 	return dst
 }
 
-// Marshal Tags. Used for Serialization so string escaping should be as in RFC8259.
-func (tags Tags) marshalTo(dst []byte) []byte {
+// MarshalTo appends the JSON encoded byte of Tags as [][]string to dst.
+// String escaping is as described in RFC8259.
+func (tags Tags) MarshalTo(dst []byte) []byte {
 	dst = append(dst, '[')
 	for i, tag := range tags {
 		if i > 0 {

--- a/tags.go
+++ b/tags.go
@@ -12,11 +12,16 @@ type Tag []string
 
 // StartsWith checks if a tag contains a prefix.
 // for example,
-//     ["p", "abcdef...", "wss://relay.com"]
+//
+//	["p", "abcdef...", "wss://relay.com"]
+//
 // would match against
-//     ["p", "abcdef..."]
+//
+//	["p", "abcdef..."]
+//
 // or even
-//     ["p", "abcdef...", "wss://"]
+//
+//	["p", "abcdef...", "wss://"]
 func (tag Tag) StartsWith(prefix []string) bool {
 	prefixLen := len(prefix)
 
@@ -140,4 +145,30 @@ func (tags Tags) ContainsAny(tagName string, values []string) bool {
 	}
 
 	return false
+}
+
+// Marshal Tag. Used for Serialization so string escaping should be as in RFC8259.
+func (tag Tag) marshalTo(dst []byte) []byte {
+	dst = append(dst, '[')
+	for i, s := range tag {
+		if i > 0 {
+			dst = append(dst, ',')
+		}
+		dst = escapeString(dst, s)
+	}
+	dst = append(dst, ']')
+	return dst
+}
+
+// Marshal Tags. Used for Serialization so string escaping should be as in RFC8259.
+func (tags Tags) marshalTo(dst []byte) []byte {
+	dst = append(dst, '[')
+	for i, tag := range tags {
+		if i > 0 {
+			dst = append(dst, ',')
+		}
+		dst = tag.marshalTo(dst)
+	}
+	dst = append(dst, ']')
+	return dst
 }

--- a/tags.go
+++ b/tags.go
@@ -157,7 +157,7 @@ func (tag Tag) marshalTo(dst []byte) []byte {
 
 // MarshalTo appends the JSON encoded byte of Tags as [][]string to dst.
 // String escaping is as described in RFC8259.
-func (tags Tags) MarshalTo(dst []byte) []byte {
+func (tags Tags) marshalTo(dst []byte) []byte {
 	dst = append(dst, '[')
 	for i, tag := range tags {
 		if i > 0 {

--- a/tags.go
+++ b/tags.go
@@ -12,15 +12,10 @@ type Tag []string
 
 // StartsWith checks if a tag contains a prefix.
 // for example,
-//
 //	["p", "abcdef...", "wss://relay.com"]
-//
 // would match against
-//
 //	["p", "abcdef..."]
-//
 // or even
-//
 //	["p", "abcdef...", "wss://"]
 func (tag Tag) StartsWith(prefix []string) bool {
 	prefixLen := len(prefix)

--- a/tags.go
+++ b/tags.go
@@ -12,11 +12,11 @@ type Tag []string
 
 // StartsWith checks if a tag contains a prefix.
 // for example,
-//	["p", "abcdef...", "wss://relay.com"]
+//     ["p", "abcdef...", "wss://relay.com"]
 // would match against
-//	["p", "abcdef..."]
+//     ["p", "abcdef..."]
 // or even
-//	["p", "abcdef...", "wss://"]
+//     ["p", "abcdef...", "wss://"]
 func (tag Tag) StartsWith(prefix []string) bool {
 	prefixLen := len(prefix)
 


### PR DESCRIPTION
1. RFC8259 compatible `MarshalJSON()` and `Serialize()` for events.
2. Using fast Marshaling Unmarshaling in relay.go.
3. moved `escapeString` to helpers.go.

Have been testing publishing/subscribing with many relays. Seems like this fixes #28


