### PR TITLE
Fix example compilation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,35 @@ A set of useful things for [Nostr Protocol](https://github.com/nostr-protocol/no
 
 <a href="https://godoc.org/github.com/nbd-wtf/go-nostr"><img src="https://img.shields.io/badge/api-reference-blue.svg?style=flat-square" alt="GoDoc"></a>
 
+Install go-nostr:
+
+```bash
+go get github.com/nbd-wtf/go-nostr
+```
+
 ### Generating a key
 
 ``` go
-sk, _ := nostr.GenerateKey()
-pk, _ := nostr.GetPublicKey(sk)
-nsec, _ := nip19.EncodePrivateKey(sk)
-npub, _ := nip19.EncodePublicKey(pk)
+package main
 
-fmt.Println("sk:", sk)
-fmt.Println("pk:", nostr.GetPublicKey(sk))
-fmt.Println(nsec)
-fmt.Println(npub)
+import (
+    "fmt"
+
+    "github.com/nbd-wtf/go-nostr"
+    "github.com/nbd-wtf/go-nostr/nip19"
+)
+
+func main() {
+    sk := nostr.GeneratePrivateKey()
+    pk, _ := nostr.GetPublicKey(sk)
+    nsec, _ := nip19.EncodePrivateKey(sk)
+    npub, _ := nip19.EncodePublicKey(pk)
+
+    fmt.Println("sk:", sk)
+    fmt.Println("pk:", pk)
+    fmt.Println(nsec)
+    fmt.Println(npub)
+}
 ```
 
 ### Subscribing to a single relay

--- a/example/example.go
+++ b/example/example.go
@@ -62,7 +62,7 @@ func main() {
 		cancel()
 	}()
 	for ev := range sub.Events {
-		evs = append(evs, ev)
+		evs = append(evs, *ev)
 	}
 
 	filename := "example_output.json"
@@ -104,7 +104,7 @@ func main() {
 	ev.CreatedAt = time.Now()
 	ev.Kind = 1
 	var content string
-	fmt.Fprintln(os.Stderr, "enter content of note, ending with an empty newline:")
+	fmt.Fprintln(os.Stderr, "enter content of note, ending with an empty newline (ctrl+d):")
 	for {
 		if n, err := reader.Read(b[:]); err == nil {
 			content = fmt.Sprintf("%s%s", content, fmt.Sprintf("%s", b[:n]))

--- a/filter_test.go
+++ b/filter_test.go
@@ -16,7 +16,7 @@ func TestFilterUnmarshal(t *testing.T) {
 		t.Errorf("failed to parse filter json: %v", err)
 	}
 
-	if f.Since == nil || f.Since.Format("2006-01-02") != "2022-02-07" ||
+	if f.Since == nil || f.Since.UTC().Format("2006-01-02") != "2022-02-07" ||
 		f.Until != nil ||
 		f.Tags == nil || len(f.Tags) != 2 || !slices.Contains(f.Tags["something"], "bab") {
 		t.Error("failed to parse filter correctly")


### PR DESCRIPTION
1. Fix typo issue in README.md (GenerateKey -> GeneratePrivateKey);
2. Fix compiling issue in example.go;
3. Fix time comparison issue in filter_test.go, the time zone should be considered when do date/time compare. 