### PR TITLE
Fix test nip19 variable naming

### DIFF
--- a/nip19/nip19_test.go
+++ b/nip19/nip19_test.go
@@ -15,11 +15,11 @@ func TestEncodeNpub(t *testing.T) {
 }
 
 func TestEncodeNsec(t *testing.T) {
-	npub, err := EncodePrivateKey("3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d")
+	nsec, err := EncodePrivateKey("3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d")
 	if err != nil {
 		t.Errorf("shouldn't error: %s", err)
 	}
-	if npub != "nsec180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsgyumg0" {
+	if nsec != "nsec180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsgyumg0" {
 		t.Error("produced an unexpected nsec string")
 	}
 }


### PR DESCRIPTION
Minor change in `nip19/nip19_test.go`