### PR TITLE
Fix unblock mutex

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -234,7 +234,6 @@ func (r *Relay) Publish(ctx context.Context, event Event) Status {
 	}
 
 	sub := r.Subscribe(ctx, Filters{Filter{IDs: []string{event.ID}}})
-	defer mu.Unlock()
 	for {
 		select {
 		case receivedEvent := <-sub.Events:
@@ -242,6 +241,7 @@ func (r *Relay) Publish(ctx context.Context, event Event) Status {
 				// we got a success, so update our status and proceed to return
 				mu.Lock()
 				status = PublishStatusSucceeded
+				mu.Unlock()
 				return status
 			}
 		case <-ctx.Done():
@@ -250,7 +250,6 @@ func (r *Relay) Publish(ctx context.Context, event Event) Status {
 			// e.g. if this happens because of the timeout then status will probably be "failed"
 			//      but if it happens because okCallback was called then it might be "succeeded"
 			// do not return if okCallback is in process
-			mu.Lock()
 			return status
 		}
 	}


### PR DESCRIPTION
- if `receivedEvent.ID` not match `event.ID`, may trigger an error `fatal error: sync: unlock of unlocked mutex`.
- if context canceled, it does not needs mutex.