### PR TITLE
nip50: add filter.search field

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -17,6 +17,7 @@ type Filter struct {
 	Since   *time.Time
 	Until   *time.Time
 	Limit   int
+	Search  string
 }
 
 type TagMap map[string][]string
@@ -106,6 +107,10 @@ func FilterEqual(a Filter, b Filter) bool {
 	}
 
 	if a.Until != b.Until {
+		return false
+	}
+
+	if a.Search != b.Search {
 		return false
 	}
 

--- a/filter_aux.go
+++ b/filter_aux.go
@@ -61,6 +61,8 @@ func (f *Filter) UnmarshalJSON(payload []byte) error {
 				visiterr = fmt.Errorf("invalid 'limit' field: %w", err)
 			}
 			f.Limit = val
+		case "search":
+			f.Search = v.String()
 		default:
 			if strings.HasPrefix(key, "#") {
 				f.Tags[key[1:]], err = fastjsonArrayToStringList(v)
@@ -104,6 +106,9 @@ func (f Filter) MarshalJSON() ([]byte, error) {
 	}
 	if f.Limit != 0 {
 		o.Set("limit", arena.NewNumberInt(f.Limit))
+	}
+	if f.Search != "" {
+		o.Set("search", arena.NewString(f.Search))
 	}
 
 	return o.MarshalTo(nil), nil


### PR DESCRIPTION
Adds `search` filter for nip50 support.

for: https://github.com/fiatjaf/relayer/pull/37