### PR TITLE
add Before/After for Timestamp

### DIFF
--- a/timestamp.go
+++ b/timestamp.go
@@ -11,3 +11,21 @@ func Now() Timestamp {
 func (t Timestamp) Time() time.Time {
 	return time.Unix(int64(t), 0)
 }
+
+func (t Timestamp) Before(u Timesamp) bool {
+	return t < u
+}
+
+func (t Timestamp) After(u Timesamp) bool {
+	return t > u
+}
+
+func (t Timestamp) Compare(u Time) int {
+	switch {
+	case t < u:
+		return -1
+	case t > u:
+		return +1
+	}
+	return 0
+}


### PR DESCRIPTION
Many implementation using go-nostr using CreatedAt.Before/After that was implemented for older version without Timestamp can not build. This is simple way to be possible to build them.