### PR TITLE
Create new context as connection context in relay connect

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -73,7 +73,9 @@ func (r *Relay) String() string {
 // Once successfully connected, context expiration has no effect: call r.Close
 // to close the connection.
 func (r *Relay) Connect(ctx context.Context) error {
-	connectionContext, cancel := context.WithCancel(ctx)
+	// New context must be created here because incoming ctx cancellation will affect internal logic
+	// TODO: replace in go 1.21 with context.WithoutCancel(ctx)
+	connectionContext, cancel := context.WithCancel(context.Background())
 	r.ConnectionContext = connectionContext
 	r.connectionContextCancel = cancel
 


### PR DESCRIPTION
New context must be created here because incoming ctx cancellation will affect internal logic.

If incoming context is cancelled - it will stop the whole connection to relay (except real http connection).

How I found it:
if connection context is cancelled by timeout (for example if you are connecting to relay with context that contains timeout) - you will always get "sent" status instead of real status from the Publish method (https://github.com/nbd-wtf/go-nostr/blob/master/relay.go#L318).