### PR TITLE
Fix GetImmediateReply

### DIFF
--- a/nip10/nip10.go
+++ b/nip10/nip10.go
@@ -16,7 +16,7 @@ func GetImmediateReply(tags nostr.Tags) *nostr.Tag {
 	var root *nostr.Tag
 	var lastE *nostr.Tag
 
-	for i := len(tags) - 1; i >= 0; i-- {
+	for i := 0; i <= len(tags)-1; i++ {
 		tag := tags[i]
 
 		if len(tag) < 2 {


### PR DESCRIPTION
When scanning an event with positional "e" tags the reply is the last one.