### PR TITLE
ci: update checkout and setup-go action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
         with:
           go-version-file: ./go.mod
+
       - run: go test ./...


### PR DESCRIPTION
- update `actions/checkout` to v4 
- update `actions/setup-go` to v5 

To solve deprecation warnings in GitHub actions which were warning about old node 12 and node 16 action runtimes.

Also took the liberty of adding some whitespace between steps. Hopefully acceptable 😸 