### PR TITLE
changed nostr relays from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ func main() {
 
 ``` go
 ctx := context.Background()
-relay, err := nostr.RelayConnect(ctx, "wss://nostr.zebedee.cloud")
+relay, err := nostr.RelayConnect(ctx, "wss://relay.stoner.com")
 if err != nil {
 	panic(err)
 }
@@ -95,7 +95,7 @@ ev.Sign(sk)
 
 // publish the event to two relays
 ctx := context.Background()
-for _, url := range []string{"wss://nostr.zebedee.cloud", "wss://nostr-pub.wellorder.net"} {
+for _, url := range []string{"wss://relay.stoner.com", "wss://nostr-pub.wellorder.net"} {
 	relay, err := nostr.RelayConnect(ctx, url)
 	if err != nil {
 		fmt.Println(err)

--- a/example/example.go
+++ b/example/example.go
@@ -17,7 +17,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 
 	// connect to relay
-	url := "wss://nostr.zebedee.cloud"
+	url := "wss://relay.stoner.com"
 	relay, err := nostr.RelayConnect(ctx, url)
 	if err != nil {
 		panic(err)
@@ -116,7 +116,7 @@ func main() {
 	}
 	ev.Content = strings.TrimSpace(content)
 	ev.Sign(sk)
-	for _, url := range []string{"wss://nostr.zebedee.cloud"} {
+	for _, url := range []string{"wss://relay.stoner.com"} {
 		ctx := context.WithValue(context.Background(), "url", url)
 		relay, e := nostr.RelayConnect(ctx, url)
 		if e != nil {


### PR DESCRIPTION
I was seeing this issue #100, I went to test it and it seems that the wss://nostr.zebedee.cloud relay is no longer available.

I switched to wss://relay.stoner.com and now it seems to be working fine.
