### PR TITLE
Support a tags in GetImmediateReply

### DIFF
--- a/nip10/nip10.go
+++ b/nip10/nip10.go
@@ -22,7 +22,7 @@ func GetImmediateReply(tags nostr.Tags) *nostr.Tag {
 		if len(tag) < 2 {
 			continue
 		}
-		if tag[0] != "e" {
+		if tag[0] != "e" && tag[0] != "a" {
 			continue
 		}
 


### PR DESCRIPTION
I'm not sure if this fix break something, I'm using it on njump to retrieve the parent of comments to an naddr1 event.