### PR TITLE
Append 'ws://' prefix if url starts with localhost

### DIFF
--- a/normalize.go
+++ b/normalize.go
@@ -15,6 +15,10 @@ func NormalizeURL(u string) string {
 	u = strings.TrimSpace(u)
 	u = strings.ToLower(u)
 
+	if strings.HasPrefix(u, "localhost") == true {
+		u = "ws://" + u
+	}
+
 	if !strings.HasPrefix(u, "http") && !strings.HasPrefix(u, "ws") {
 		u = "wss://" + u
 	}

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -1,32 +1,33 @@
 package nostr
 
-import "fmt"
+import (
+	"testing"
+)
 
-func ExampleNormalizeURL() {
-	fmt.Println(NormalizeURL(""))
-	fmt.Println(NormalizeURL("wss://x.com/y"))
-	fmt.Println(NormalizeURL("wss://x.com/y/"))
-	fmt.Println(NormalizeURL("http://x.com/y"))
-	fmt.Println(NormalizeURL(NormalizeURL("http://x.com/y")))
-	fmt.Println(NormalizeURL("wss://x.com"))
-	fmt.Println(NormalizeURL("wss://x.com/"))
-	fmt.Println(NormalizeURL(NormalizeURL(NormalizeURL("wss://x.com/"))))
-	fmt.Println(NormalizeURL("x.com"))
-	fmt.Println(NormalizeURL("x.com/"))
-	fmt.Println(NormalizeURL("x.com////"))
-	fmt.Println(NormalizeURL("x.com/?x=23"))
+type urlTest struct {
+	url, expected string
+}
 
-	// Output:
-	//
-	// wss://x.com/y
-	// wss://x.com/y
-	// ws://x.com/y
-	// ws://x.com/y
-	// wss://x.com
-	// wss://x.com
-	// wss://x.com
-	// wss://x.com
-	// wss://x.com
-	// wss://x.com
-	// wss://x.com?x=23
+var urlTests = []urlTest{
+	{"", ""},
+	{"wss://x.com/y", "wss://x.com/y"},
+	{"wss://x.com/y/", "wss://x.com/y"},
+	{"http://x.com/y", "ws://x.com/y"},
+	{NormalizeURL("http://x.com/y"), "ws://x.com/y"},
+	{NormalizeURL("wss://x.com"), "wss://x.com"},
+	{NormalizeURL("wss://x.com/"), "wss://x.com"},
+	{NormalizeURL(NormalizeURL(NormalizeURL("wss://x.com/"))), "wss://x.com"},
+	{"wss://x.com", "wss://x.com"},
+	{"wss://x.com/", "wss://x.com"},
+	{"x.com////", "wss://x.com"},
+	{"x.com/?x=23", "wss://x.com?x=23"},
+}
+
+func TestNormalizeURL(t *testing.T) {
+
+	for _, test := range urlTests {
+		if output := NormalizeURL(test.url); output != test.expected {
+			t.Errorf("Output '%s' not equal to expected '%s'", output, test.expected)
+		}
+	}
 }

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -21,6 +21,9 @@ var urlTests = []urlTest{
 	{"wss://x.com/", "wss://x.com"},
 	{"x.com////", "wss://x.com"},
 	{"x.com/?x=23", "wss://x.com?x=23"},
+	{"localhost:4036", "ws://localhost:4036"},
+	{"localhost:4036/relay", "ws://localhost:4036/relay"},
+	{NormalizeURL("localhost:4036/relay"), "ws://localhost:4036/relay"},
 }
 
 func TestNormalizeURL(t *testing.T) {


### PR DESCRIPTION
Related: https://github.com/fiatjaf/nak/pull/22  

Without thinking much and doing things in a hurry, the commit above is wrong because `nak req` or `nak event` actually use under the hood the function `NormalizeURL`, and I thought they used the file `relay.go` in the [nak](https://github.com/fiatjaf/nak) repository.  

However, the commit above is not totally wrong, in a sense that the commit doesn't need to be removed, because it works with the `relay` flag. Image above.  
![image](https://github.com/nbd-wtf/go-nostr/assets/76563803/a281bc90-5719-45f0-a146-fe89428ea4ff)

My bad.