### PR TITLE
nip46: fix HandleRequest request parsing logic

### DIFF
--- a/nip46/dynamic-signer.go
+++ b/nip46/dynamic-signer.go
@@ -105,11 +105,11 @@ func (p *DynamicSigner) HandleRequest(event *nostr.Event) (
 		}
 
 		p.setSession(event.PubKey, session)
+	}
 
-		req, err = session.ParseRequest(event)
-		if err != nil {
-			return req, resp, eventResponse, fmt.Errorf("error parsing request: %w", err)
-		}
+	req, err = session.ParseRequest(event)
+	if err != nil {
+		return req, resp, eventResponse, fmt.Errorf("error parsing request: %w", err)
 	}
 
 	var secret string


### PR DESCRIPTION
Move out the `session.ParseRequest` call from the `else` branch. This caused an empty `Request` object to be used down in the function when the `Session` already existed.