### PR TITLE
nip17: fix nil pointer

### DIFF
--- a/nip17/nip17.go
+++ b/nip17/nip17.go
@@ -55,7 +55,7 @@ func PublishMessage(
 		}
 
 		err = r.Publish(ctx, event)
-		if strings.HasPrefix(err.Error(), "auth-required:") {
+		if err != nil && strings.HasPrefix(err.Error(), "auth-required:") {
 			authErr := r.Auth(ctx, func(ae *nostr.Event) error { return kr.SignEvent(ctx, ae) })
 			if authErr == nil {
 				err = r.Publish(ctx, event)


### PR DESCRIPTION
Fixes a nil pointer when the Publish succeeds.
In that case the err is nil, and calling .Error() on nil causes a nil pointer exception.
Reproduced at: https://play.golang.com/p/ps8d82Qt9kO

Probably it could be worth to cherry pick this for a v0.45.1