### PR TITLE
sdk/feeds: fix nil pointer error and conditional local query logic

### DIFF
--- a/sdk/feeds.go
+++ b/sdk/feeds.go
@@ -121,7 +121,7 @@ func (sys *System) FetchFeedPage(
 			filter.Since = &oldest
 		}
 
-		if filter.Since != nil && *filter.Until < until {
+		if filter.Since != nil && *filter.Since < until {
 			// eligible for a local query
 			filter.Until = &until
 			res, err := sys.StoreRelay.QuerySync(ctx, filter)
@@ -156,7 +156,7 @@ func (sys *System) FetchFeedPage(
 				events = append(events, ie.Event)
 			}
 			wg.Done()
-			if oldest != 0 && oldest < *filter.Until {
+			if oldest != 0 && filter.Until != nil && oldest < *filter.Until {
 				sys.KVStore.Set(oldestKey, encodeTimestamp(oldest))
 			}
 		}()


### PR DESCRIPTION
Fix a nil pointer that occurs in FetchFeedPage when no data is returned from the KVStore.
Updates conditions on which to query locally to ensure it's only happening if the oldest timestamp in the KVStore for a pubkey is older than the upper bound of the time filter.

Locally reproduced with:
```go
package main

import (
	"context"
	"fmt"
	"time"

	"github.com/nbd-wtf/go-nostr"
	"github.com/nbd-wtf/go-nostr/nip19"
	"github.com/nbd-wtf/go-nostr/sdk"
)

func main() {
	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
	defer cancel()
	_, pubkey, err := nip19.Decode("npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6")
	if err != nil {
		panic("Unable to decode npub")
	}
	sys := sdk.NewSystem()

	until := nostr.Now()
	events, err := sys.FetchFeedPage(ctx, []string{pubkey.(string)}, []int{nostr.KindTextNote}, until, 1)
	print(fmt.Sprintf("%v", events))
}
```
