### PR TITLE
nipb0: Add authorization headers to Blossom downloads

### DIFF
--- a/nipb0/blossom/download.go
+++ b/nipb0/blossom/download.go
@@ -21,6 +21,12 @@ func (c *Client) Download(ctx context.Context, hash string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
+	authHeader := c.authorizationHeader(ctx, func(evt *nostr.Event) {
+		evt.Tags = append(evt.Tags, nostr.Tag{"t", "get"})
+		evt.Tags = append(evt.Tags, nostr.Tag{"x", hash})
+	})
+	req.Header.Add("Authorization", authHeader)
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call %s for %s: %w", c.mediaserver, hash, err)
@@ -44,6 +50,12 @@ func (c *Client) DownloadToFile(ctx context.Context, hash string, filePath strin
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
+
+	authHeader := c.authorizationHeader(ctx, func(evt *nostr.Event) {
+		evt.Tags = append(evt.Tags, nostr.Tag{"t", "get"})
+		evt.Tags = append(evt.Tags, nostr.Tag{"x", hash})
+	})
+	req.Header.Add("Authorization", authHeader)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
This PR adds authorization headers to the blossom download functions, in order to make it compatible with servers that require [Get Authorization](https://github.com/hzrd149/blossom/blob/master/buds/01.md#get-authorization-optional).

## Testing

### Versions used for testing

**go-nostr:** e1f38a17178e178ffe776b96b1ef458dcb94f454
**nak:** https://github.com/fiatjaf/nak/commit/c60bb82be84c64d1c025b0ccff10f0d2a42358fe _(built with this modified version of `go-nostr`)_
**blobstr-relay:** _(A Blossom relay built with Khatru, that uses Get Authorization)_ https://github.com/Leaf-Computer/blobstr-relay/commit/b9bae6b56da721777badbff45127838c6c391316

**Setup:**
- Roughly steps 1–9 in [this example](https://github.com/Leaf-Computer/blobstr-relay/tree/b9bae6b56da721777badbff45127838c6c391316?tab=readme-ov-file#example-usage), which essentially means a Blossom server that only allows downloads for a particular blob from an authorized keypair.

**Steps:**
1. Try downloading a file using an unauthorized key.
```
./nak blossom download --sec=$KEY_3 --server http://localhost:3334 --output ~/Downloads/download.png 9e0db9b76dddf8cd69c9778993da62e5975634d38583a2ac87536488bd4e82fe
```
_(This returns a 403)_

2. Try downloading a file using an authorized key.
```
./nak blossom download --sec=$KEY_2 --server http://localhost:3334 --output ~/Downloads/download.png 9e0db9b76dddf8cd69c9778993da62e5975634d38583a2ac87536488bd4e82fe
```
_(This successfully downloads the file)_
