### PR TITLE
NIP-42 panic when there is no "relay" tag.

### DIFF
--- a/nip42/nip42.go
+++ b/nip42/nip42.go
@@ -48,7 +48,12 @@ func ValidateAuthEvent(event *nostr.Event, challenge string, relayURL string) (p
 		return "", false
 	}
 
-	found, err := parseURL(event.Tags.GetFirst([]string{"relay", ""}).Value())
+	tag := event.Tags.Find("relay")
+	if tag == nil {
+		return "", false
+	}
+
+	found, err := parseURL(tag[1])
 	if err != nil {
 		return "", false
 	}


### PR DESCRIPTION
When there is no relay tag, `ValidateAuthEvent` panics. To test it you can simply run

```golang
package main

import (
	"fmt"

	"github.com/nbd-wtf/go-nostr"
	"github.com/nbd-wtf/go-nostr/nip42"
)

func main() {
	auth := nostr.Event{
		Kind: nostr.KindClientAuthentication,
		Tags: nostr.Tags{{"challenge", "abc"}},
	}

	nip42.ValidateAuthEvent(&auth, "abc", "")
}
```