### PR TITLE
set default InfoLogger DebugLogger to io.Discard

### DIFF
--- a/log.go
+++ b/log.go
@@ -2,13 +2,13 @@ package nostr
 
 import (
 	"log"
-	"os"
+	"io"
 )
 
 var (
 	// call SetOutput on InfoLogger to enable info logging
-	InfoLogger = log.New(os.Stderr, "[go-nostr][info] ", log.LstdFlags)
+	InfoLogger = log.New(io.Discard, "[go-nostr][info] ", log.LstdFlags)
 
 	// call SetOutput on DebugLogger to enable debug logging
-	DebugLogger = log.New(os.Stderr, "[go-nostr][debug] ", log.LstdFlags)
+	DebugLogger = log.New(io.Discard, "[go-nostr][debug] ", log.LstdFlags)
 )


### PR DESCRIPTION
As applications want select for themselves what gets written to stderr or stdout. Particularly when it gets passed through to parent processes that aren't just writing it to a log file.