### PR TITLE
fix check duplicate for pool subMany

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -491,7 +491,7 @@ func (pool *SimplePool) subMany(
 
 			subscribe:
 				sub, err = relay.Subscribe(ctx, filters, append(opts, WithCheckDuplicate(func(id, relay string) bool {
-					_, exists := seenAlready.Load(id)
+					_, exists := seenAlready.LoadAndStore(id, Timestamp(time.Now().Unix()))
 					if exists && pool.duplicateMiddleware != nil {
 						pool.duplicateMiddleware(relay, id)
 					}


### PR DESCRIPTION
I know this is already fixed in new `nostrlib` ngit thingy, but until we are able to refactor code to use that, would be cool to have this backport fix to `nbd-wtf/go-nostr` @fiatjaf 
Thanks.