### PR TITLE
feat: add opt WithOrderedEvents

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -435,6 +435,8 @@ func (r *Relay) PrepareSubscription(ctx context.Context, filters Filters, opts .
 			sub.checkDuplicate = o
 		case WithCheckDuplicateReplaceable:
 			sub.checkDuplicateReplaceable = o
+		case WithOrderedEvents:
+			sub.ordered = bool(o) 
 		}
 	}
 


### PR DESCRIPTION
**Title:**
Add `WithOrderedEvents` option for sequential event dispatch

**Description:**
This PR introduces a new subscription option `WithOrderedEvents` that allows users to control how events are dispatched:

* **`true`**: events are dispatched sequentially, preserving order.
* **`false` (default)**: events are dispatched asynchronously, as before.

This addresses scenarios where event order matters, especially when consuming relays that may emit events out of order.

**Usage Example:**

```go
sub, err := relay.Subscribe(
    ctx,
    nostr.Filters{{Kinds: []int{1}}},
    nostr.WithOrderedEvents(true), // enable ordered dispatch
)
```

**Notes:**

* Backwards compatible: existing subscriptions default to asynchronous dispatch.
* No breaking changes to existing `SubscriptionOption`s.
* This helps prevent race conditions or out-of-order processing in consumers that rely on event sequence.